### PR TITLE
Add ability to release cursor

### DIFF
--- a/vinox-client/src/states/game/input/player.rs
+++ b/vinox-client/src/states/game/input/player.rs
@@ -213,6 +213,7 @@ pub fn interact(
     mut commands: Commands,
     mouse_button_input: Res<Input<MouseButton>>,
     keys: Res<Input<KeyCode>>,
+    windows: Query<&mut Window, With<PrimaryWindow>>,
     camera_query: Query<&GlobalTransform, With<Camera>>,
     mut client: ResMut<Client>,
     player_position: Query<&Transform, With<ControlledPlayer>>,
@@ -225,6 +226,13 @@ pub fn interact(
     current_chunks: Res<CurrentChunks>,
     block_table: Res<BlockTable>,
 ) {
+    if let Ok(window) = windows.get_single() {
+        if window.cursor.grab_mode != CursorGrabMode::Locked {
+            return;
+        }
+    } else {
+        return;
+    }
     let item_string = match current_item.clone() {
         CurrentItem::Grass => BlockData::new("vinox".to_string(), "grass".to_string()),
         CurrentItem::Dirt => BlockData::new("vinox".to_string(), "dirt".to_string()),
@@ -471,3 +479,35 @@ pub fn collision_movement_system(
         }
     }
 }
+
+pub fn cursor_grab_system(
+    mut windows: Query<&mut Window, With<PrimaryWindow>>,
+    btn: Res<Input<MouseButton>>,
+    key: Res<Input<KeyCode>>,
+) {
+    let Ok(mut window) = windows.get_single_mut() else {
+        return;
+    };
+
+    if btn.just_pressed(MouseButton::Left) {
+        window.cursor.grab_mode = CursorGrabMode::Locked;
+        window.cursor.visible = false;
+        let window_center: Option<Vec2> =
+            Some(Vec2::new(window.width() / 2.0, window.height() / 2.0));
+        window.set_cursor_position(window_center);
+    }
+
+    if key.just_pressed(KeyCode::Escape) {
+        let window_center: Option<Vec2> =
+            Some(Vec2::new(window.width() / 2.0, window.height() / 2.0));
+        window.set_cursor_position(window_center);
+        if window.cursor.grab_mode == CursorGrabMode::None {
+            window.cursor.grab_mode = CursorGrabMode::Locked;
+            window.cursor.visible = false;
+        } else {
+            window.cursor.grab_mode = CursorGrabMode::None;
+            window.cursor.visible = true;
+        }
+    }
+}
+

--- a/vinox-client/src/states/game/input/plugin.rs
+++ b/vinox-client/src/states/game/input/plugin.rs
@@ -3,7 +3,8 @@ use bevy::prelude::*;
 use crate::states::components::GameState;
 
 use super::player::{
-    collision_movement_system, interact, movement_input, spawn_camera, MouseSensitivity,
+    collision_movement_system, cursor_grab_system, interact, movement_input,
+    spawn_camera, MouseSensitivity,
 };
 
 pub struct InputPlugin;
@@ -16,6 +17,7 @@ impl Plugin for InputPlugin {
                 movement_input,
                 interact,
                 collision_movement_system,
+                cursor_grab_system.after(interact),
             )
                 .in_set(OnUpdate(GameState::Game)),
         );


### PR DESCRIPTION
I'm a baby at rust and bevy, advice appreciated

Added the ability to use Escape to toggle cursor, and left click to capture cursor.

Cursor system has to be before the interact system otherwise the interact system might read a left click when you were simply selecting the game window